### PR TITLE
Added Loot Table datagen. Added sticks to the short/tall grass loot table.

### DIFF
--- a/src/client/java/com/tcm/MineTale/MineTaleDataGen.java
+++ b/src/client/java/com/tcm/MineTale/MineTaleDataGen.java
@@ -1,9 +1,6 @@
 package com.tcm.MineTale;
 
-import com.tcm.MineTale.datagen.ModBlockTagProvider;
-import com.tcm.MineTale.datagen.ModLangProvider;
-import com.tcm.MineTale.datagen.ModModelProvider;
-import com.tcm.MineTale.datagen.ModRecipeProvider;
+import com.tcm.MineTale.datagen.*;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
@@ -26,5 +23,6 @@ public class MineTaleDataGen implements DataGeneratorEntrypoint {
         pack.addProvider(ModModelProvider::new);
         pack.addProvider(ModRecipeProvider::new);
         pack.addProvider(ModBlockTagProvider::new);
+        pack.addProvider(ModLootTableProvider::new);
     }
 }

--- a/src/client/java/com/tcm/MineTale/MineTaleDataGen.java
+++ b/src/client/java/com/tcm/MineTale/MineTaleDataGen.java
@@ -8,10 +8,10 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 public class MineTaleDataGen implements DataGeneratorEntrypoint {
 
     /**
-     * Initialize a data pack and register the mod's data providers.
+     * Initialize a data pack and register the mod's data providers for data generation.
      *
-     * Creates a data pack from the given Fabric data generator and adds the language
-     * and model providers so they will run during data generation.
+     * Registers language, model, recipe, block tag, and loot table providers so they
+     * will run as part of the Fabric data generation pack created from the given generator.
      *
      * @param fabricDataGenerator the Fabric data generator used to create the data pack
      */

--- a/src/client/java/com/tcm/MineTale/datagen/ModBlockTagProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModBlockTagProvider.java
@@ -21,11 +21,13 @@ public class ModBlockTagProvider extends FabricTagProvider.BlockTagProvider {
     }
 
     /**
-     * Populates the BlockTags.LOGS tag with this mod's log blocks.
+     * Populate block tags with this mod's blocks.
      *
-     * Registers each mod-defined log block so they are included in the game's LOGS tag mapping.
+     * Adds mod-defined blocks to relevant vanilla block tags (for example
+     * MINEABLE_WITH_PICKAXE, MINEABLE_WITH_AXE, and LOGS) so they are included
+     * in the game's tag mappings.
      *
-     * @param provider a registry lookup provider used to resolve holders during tag population
+     * @param provider registry lookup provider used to resolve holders during tag population
      */
     @Override
     protected void addTags(HolderLookup.Provider provider) {

--- a/src/client/java/com/tcm/MineTale/datagen/ModBlockTagProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModBlockTagProvider.java
@@ -1,5 +1,6 @@
 package com.tcm.MineTale.datagen;
 
+import com.jcraft.jorbis.Block;
 import com.tcm.MineTale.registry.ModBlocks;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
@@ -28,6 +29,14 @@ public class ModBlockTagProvider extends FabricTagProvider.BlockTagProvider {
      */
     @Override
     protected void addTags(HolderLookup.Provider provider) {
+        valueLookupBuilder(BlockTags.MINEABLE_WITH_PICKAXE)
+                .add(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1)
+                .add(ModBlocks.FURNACE_WORKBENCH_BLOCK_T2)
+                .add(ModBlocks.ARMORERS_WORKBENCH_BLOCK);
+        valueLookupBuilder(BlockTags.MINEABLE_WITH_AXE)
+                .add(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK)
+                .add(ModBlocks.WORKBENCH_WORKBENCH_BLOCK);
+
         valueLookupBuilder(BlockTags.LOGS)
                 .add(ModBlocks.AMBER_LOG)
                 .add(ModBlocks.BAMBOO_LOG)

--- a/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
@@ -1,0 +1,65 @@
+package com.tcm.MineTale.datagen;
+
+import com.tcm.MineTale.registry.ModBlocks;
+import com.tcm.MineTale.registry.ModItems;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ModLootTableProvider extends FabricBlockLootTableProvider {
+    public ModLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registryLookup) {
+        super(dataOutput, registryLookup);
+    }
+
+    @Override
+    public void generate() {
+        ///Block Drops Itself
+        //Bug!! Workbenches currently drop items based on the amount of blocks
+        //the multiblock is. For example the Furnaces currently drop 4 furnaces.
+        dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
+        dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
+        dropSelf(ModBlocks.ARMORERS_WORKBENCH_BLOCK);
+        dropSelf(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK);
+        dropSelf(ModBlocks.WORKBENCH_WORKBENCH_BLOCK);
+    }
+
+
+/// For Ore Drops
+/** Ex:
+ *  add(ModBlocks.IRON_ORE_SHALE, AverageOreDrops(ModBlocks.IRON_ORE_SHALE, Items.RAW_IRON));
+ * **/
+    public LootTable.Builder AverageOreDrops(Block drop, Item item) {
+        HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)
+                LootItem.lootTableItem(item).apply(SetItemCountFunction.setCount(UniformGenerator.between(2, 5))))
+                .apply(ApplyBonusCount.addOreBonusCount(impl.getOrThrow(Enchantments.FORTUNE)))));
+    }
+
+    public LootTable.Builder SingleOreDrops(Block drop, Item item) {
+        HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)
+                LootItem.lootTableItem(item).apply(SetItemCountFunction.setCount(ConstantValue.exactly(1))))
+                .apply(ApplyBonusCount.addOreBonusCount(impl.getOrThrow(Enchantments.FORTUNE)))));
+    }
+
+    public LootTable.Builder LightOreDrops(Block drop, Item item) {
+        HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)
+                LootItem.lootTableItem(item).apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 2))))
+                .apply(ApplyBonusCount.addOreBonusCount(impl.getOrThrow(Enchantments.FORTUNE)))));
+    }
+}

--- a/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
@@ -1,20 +1,27 @@
 package com.tcm.MineTale.datagen;
 
+import com.tcm.MineTale.block.workbenches.AbstractWorkbench;
 import com.tcm.MineTale.registry.ModBlocks;
 import com.tcm.MineTale.registry.ModItems;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.properties.ChestType;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
 import net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.predicates.ExplosionCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePropertyCondition;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 
@@ -30,11 +37,26 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
         ///Block Drops Itself
         //Bug!! Workbenches currently drop items based on the amount of blocks
         //the multiblock is. For example the Furnaces currently drop 4 furnaces.
-        dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
-        dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
+        // dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
+        // dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
         dropSelf(ModBlocks.ARMORERS_WORKBENCH_BLOCK);
         dropSelf(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK);
         dropSelf(ModBlocks.WORKBENCH_WORKBENCH_BLOCK);
+
+        this.add(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1, 
+            LootTable.lootTable() // Use the static factory method to start the builder
+                .withPool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1.0F))
+                    .add(LootItem.lootTableItem(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1))
+                    .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1)
+                        .setProperties(StatePropertiesPredicate.Builder.properties()
+                            .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
+                            .hasProperty(AbstractWorkbench.TYPE, ChestType.LEFT)
+                        )
+                    )
+                    .when(ExplosionCondition.survivesExplosion())
+                )
+        );
     }
 
 

--- a/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
@@ -28,10 +28,25 @@ import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 import java.util.concurrent.CompletableFuture;
 
 public class ModLootTableProvider extends FabricBlockLootTableProvider {
+    /**
+     * Creates a ModLootTableProvider used to generate the mod's block loot tables.
+     *
+     * Initializes the provider with the data output target and a future registry lookup used to resolve game registries during loot table generation.
+     *
+     * @param dataOutput     the data output target for generated data
+     * @param registryLookup a future that provides a HolderLookup.Provider for resolving registries needed while generating loot tables
+     */
     public ModLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registryLookup) {
         super(dataOutput, registryLookup);
     }
 
+    /**
+     * Registers loot tables for the mod's workbench blocks.
+     *
+     * Each added loot table causes the block to drop itself (one item) only when the block's state
+     * matches the required DoubleBlockHalf (LOWER) and ChestType (LEFT or SINGLE) for that block,
+     * and the drop is subject to explosion survival/decay.
+     */
     @Override
     public void generate() {
         ///Block Drops Itself
@@ -113,9 +128,13 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
 
 
 /// For Ore Drops
-/** Ex:
- *  add(ModBlocks.IRON_ORE_SHALE, AverageOreDrops(ModBlocks.IRON_ORE_SHALE, Items.RAW_IRON));
- * **/
+/**
+     * Create a loot table builder that drops the specified item in multiple quantities with Silk Touch, Fortune bonus, and explosion decay applied.
+     *
+     * @param drop  the source block used for Silk Touch dispatch and explosion-decay context
+     * @param item  the item to drop from the ore
+     * @return      a LootTable.Builder that drops `item` in a base count between 2 and 5, augmented by the Fortune enchantment, with Silk Touch handling and explosion decay applied
+     */
     public LootTable.Builder AverageOreDrops(Block drop, Item item) {
         HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
         return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)
@@ -123,6 +142,17 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
                 .apply(ApplyBonusCount.addOreBonusCount(impl.getOrThrow(Enchantments.FORTUNE)))));
     }
 
+    /**
+     * Creates a loot table builder for an ore that yields the specified item with Silk Touch and Fortune handling.
+     *
+     * The table gives a base drop count of exactly 1 (before Fortune), increases the count with Fortune, returns the
+     * ore block when mined with Silk Touch, and applies explosion decay to the drop.
+     *
+     * @param drop  the ore block (returned when Silk Touch is used)
+     * @param item  the item to drop when the ore is mined without Silk Touch
+     * @return      a LootTable.Builder configured to drop the specified item with Fortune bonuses, Silk Touch dispatch,
+     *              and explosion decay
+     */
     public LootTable.Builder SingleOreDrops(Block drop, Item item) {
         HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
         return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)
@@ -130,6 +160,14 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
                 .apply(ApplyBonusCount.addOreBonusCount(impl.getOrThrow(Enchantments.FORTUNE)))));
     }
 
+    /**
+     * Builds a loot table for a "light" ore block that supports Silk Touch, Fortune bonuses, and explosion decay.
+     *
+     * @param drop  the ore block whose loot table is being created
+     * @param item  the item to drop from the ore when not Silk Touched
+     * @return      a LootTable.Builder that drops {@code item} in quantities of 1–2 (before Fortune), applies Fortune bonus,
+     *              dispatches to Silk Touch drops when applicable, and respects explosion decay
+     */
     public LootTable.Builder LightOreDrops(Block drop, Item item) {
         HolderLookup.RegistryLookup<Enchantment> impl = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
         return this.createSilkTouchDispatchTable(drop, this.applyExplosionDecay(drop, ((LootPoolSingletonContainer.Builder<?>)

--- a/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
@@ -35,8 +35,6 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
     @Override
     public void generate() {
         ///Block Drops Itself
-        dropSelf(ModBlocks.ARMORERS_WORKBENCH_BLOCK);
-
         this.add(ModBlocks.ARMORERS_WORKBENCH_BLOCK, 
             LootTable.lootTable() // Use the static factory method to start the builder
                 .withPool(LootPool.lootPool()

--- a/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
+++ b/src/client/java/com/tcm/MineTale/datagen/ModLootTableProvider.java
@@ -35,13 +35,52 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
     @Override
     public void generate() {
         ///Block Drops Itself
-        //Bug!! Workbenches currently drop items based on the amount of blocks
-        //the multiblock is. For example the Furnaces currently drop 4 furnaces.
-        // dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
-        // dropSelf(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1);
         dropSelf(ModBlocks.ARMORERS_WORKBENCH_BLOCK);
-        dropSelf(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK);
-        dropSelf(ModBlocks.WORKBENCH_WORKBENCH_BLOCK);
+
+        this.add(ModBlocks.ARMORERS_WORKBENCH_BLOCK, 
+            LootTable.lootTable() // Use the static factory method to start the builder
+                .withPool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1.0F))
+                    .add(LootItem.lootTableItem(ModBlocks.ARMORERS_WORKBENCH_BLOCK))
+                    .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.ARMORERS_WORKBENCH_BLOCK)
+                        .setProperties(StatePropertiesPredicate.Builder.properties()
+                            .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
+                            .hasProperty(AbstractWorkbench.TYPE, ChestType.LEFT)
+                        )
+                    )
+                    .when(ExplosionCondition.survivesExplosion())
+                )
+        );
+
+        this.add(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK, 
+            LootTable.lootTable() // Use the static factory method to start the builder
+                .withPool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1.0F))
+                    .add(LootItem.lootTableItem(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK))
+                    .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.CAMPFIRE_WORKBENCH_BLOCK)
+                        .setProperties(StatePropertiesPredicate.Builder.properties()
+                            .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
+                            .hasProperty(AbstractWorkbench.TYPE, ChestType.SINGLE)
+                        )
+                    )
+                    .when(ExplosionCondition.survivesExplosion())
+                )
+        );
+
+        this.add(ModBlocks.WORKBENCH_WORKBENCH_BLOCK, 
+            LootTable.lootTable() // Use the static factory method to start the builder
+                .withPool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1.0F))
+                    .add(LootItem.lootTableItem(ModBlocks.WORKBENCH_WORKBENCH_BLOCK))
+                    .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.WORKBENCH_WORKBENCH_BLOCK)
+                        .setProperties(StatePropertiesPredicate.Builder.properties()
+                            .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
+                            .hasProperty(AbstractWorkbench.TYPE, ChestType.LEFT)
+                        )
+                    )
+                    .when(ExplosionCondition.survivesExplosion())
+                )
+        );
 
         this.add(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1, 
             LootTable.lootTable() // Use the static factory method to start the builder
@@ -49,6 +88,21 @@ public class ModLootTableProvider extends FabricBlockLootTableProvider {
                     .setRolls(ConstantValue.exactly(1.0F))
                     .add(LootItem.lootTableItem(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1))
                     .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.FURNACE_WORKBENCH_BLOCK_T1)
+                        .setProperties(StatePropertiesPredicate.Builder.properties()
+                            .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
+                            .hasProperty(AbstractWorkbench.TYPE, ChestType.LEFT)
+                        )
+                    )
+                    .when(ExplosionCondition.survivesExplosion())
+                )
+        );
+
+        this.add(ModBlocks.FURNACE_WORKBENCH_BLOCK_T2, 
+            LootTable.lootTable() // Use the static factory method to start the builder
+                .withPool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1.0F))
+                    .add(LootItem.lootTableItem(ModBlocks.FURNACE_WORKBENCH_BLOCK_T2))
+                    .when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(ModBlocks.FURNACE_WORKBENCH_BLOCK_T2)
                         .setProperties(StatePropertiesPredicate.Builder.properties()
                             .hasProperty(AbstractWorkbench.HALF, DoubleBlockHalf.LOWER)
                             .hasProperty(AbstractWorkbench.TYPE, ChestType.LEFT)

--- a/src/main/java/com/tcm/MineTale/MineTale.java
+++ b/src/main/java/com/tcm/MineTale/MineTale.java
@@ -135,7 +135,16 @@ public class MineTale implements ModInitializer {
 		LOGGER.info("MineTale Loaded!");
 	}
 
-	private boolean hasIngredients(ServerPlayer player, WorkbenchRecipe recipe) {
+	/**
+     * Determines whether the player (and nearby pullable chests, if the workbench allows) collectively contain all item ingredients required by the given workbench recipe.
+     *
+     * This check requires the player's open container to be an AbstractWorkbenchContainerMenu; if it is not, the method returns `false`. It examines the player's non-equipment inventory and, when the workbench permits pulling, the contents of nearby inventories. Each recipe ingredient must be satisfied by a distinct matching item instance from those inventories.
+     *
+     * @param player the server player whose inventories are checked
+     * @param recipe the workbench recipe whose ingredient requirements are being validated
+     * @return `true` if all ingredients of the recipe can be satisfied from the player and allowed nearby inventories, `false` otherwise
+     */
+    private boolean hasIngredients(ServerPlayer player, WorkbenchRecipe recipe) {
         if (!(player.containerMenu instanceof AbstractWorkbenchContainerMenu menu)) return false;
         AbstractWorkbenchEntity be = menu.getBlockEntity();
 

--- a/src/main/java/com/tcm/MineTale/MineTale.java
+++ b/src/main/java/com/tcm/MineTale/MineTale.java
@@ -1,5 +1,6 @@
 package com.tcm.MineTale;
 
+import com.tcm.MineTale.util.ModLootTableModifiers;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -72,6 +73,8 @@ public class MineTale implements ModInitializer {
 
 		RecipeSynchronization.synchronizeRecipeSerializer(ModRecipes.FURNACE_SERIALIZER);
 
+		ModLootTableModifiers.modifyLootTables();
+
 		// Register the payload type and codec so the game knows how to handle it
 		PayloadTypeRegistry.playC2S().register(CraftRequestPayload.TYPE, CraftRequestPayload.CODEC);
 
@@ -129,7 +132,7 @@ public class MineTale implements ModInitializer {
 			});
 		});
 
-		LOGGER.info("Hello Fabric world!");
+		LOGGER.info("MineTale Loaded!");
 	}
 
 	private boolean hasIngredients(ServerPlayer player, WorkbenchRecipe recipe) {

--- a/src/main/java/com/tcm/MineTale/block/workbenches/AbstractWorkbench.java
+++ b/src/main/java/com/tcm/MineTale/block/workbenches/AbstractWorkbench.java
@@ -23,6 +23,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.*;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -32,6 +33,8 @@ import org.jetbrains.annotations.Nullable;
 import com.tcm.MineTale.block.workbenches.entity.AbstractWorkbenchEntity;
 
 import java.util.function.Supplier;
+
+// DoorBlock
 
 public abstract class AbstractWorkbench<E extends AbstractWorkbenchEntity> extends BaseEntityBlock {
     public static final EnumProperty<Direction> FACING = HorizontalDirectionalBlock.FACING;
@@ -350,5 +353,53 @@ public abstract class AbstractWorkbench<E extends AbstractWorkbenchEntity> exten
         // In your source: return blockState.isCollisionShapeFullBlock(...) ? 0.2F : 1.0F;
         // We want 1.0F to ensure the block doesn't cast a pitch-black shadow on itself.
         return 1.0F;
+    }
+
+    @Override
+    public BlockState playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
+        if (!level.isClientSide()) {
+            BlockPos masterPos = getMasterPos(state, pos);
+            boolean isMaster = pos.equals(masterPos);
+
+            // Iterate through the entire 2x2 or 1x2 structure
+            for (int y = 0; y <= (isTall ? 1 : 0); y++) {
+                for (int x = 0; x <= (isWide ? 1 : 0); x++) {
+                    Direction facing = state.getValue(FACING);
+                    BlockPos targetPos = masterPos.above(y).relative(facing.getClockWise(), x);
+
+                    // Skip the block the player is currently mining
+                    if (targetPos.equals(pos)) continue;
+
+                    BlockState targetState = level.getBlockState(targetPos);
+                    if (targetState.is(this) && getMasterPos(targetState, targetPos).equals(masterPos)) {
+                        if (isMaster) {
+                            // If we are mining the Master, destroy others SILENTLY
+                            level.setBlock(targetPos, Blocks.AIR.defaultBlockState(), 35);
+                        } else {
+                            // If we are mining a Slave block, we need to handle the Master carefully.
+                            // If the Master is at this targetPos, destroy it WITH drops.
+                            if (targetPos.equals(masterPos)) {
+                                level.destroyBlock(targetPos, !player.isCreative());
+                            } else {
+                                // Otherwise, it's just another slave block, remove silently.
+                                level.setBlock(targetPos, Blocks.AIR.defaultBlockState(), 35);
+                            }
+                        }
+                        level.gameEvent(GameEvent.BLOCK_DESTROY, targetPos, GameEvent.Context.of(player, targetState));
+                    }
+                }
+            }
+
+            // Final tweak: If the player is mining a SLAVE block, 
+            // we must prevent the slave block itself from dropping.
+            if (!isMaster && !player.isCreative()) {
+                // This prevents the current block from dropping its loot table 
+                // because we already triggered the Master's drop above.
+                state = state.setValue(BlockStateProperties.LIT, false); // Optional: change state to desync loot
+                level.setBlock(pos, Blocks.AIR.defaultBlockState(), 35);
+            }
+        }
+
+        return super.playerWillDestroy(level, pos, state, player);
     }
 }

--- a/src/main/java/com/tcm/MineTale/block/workbenches/AbstractWorkbench.java
+++ b/src/main/java/com/tcm/MineTale/block/workbenches/AbstractWorkbench.java
@@ -355,6 +355,24 @@ public abstract class AbstractWorkbench<E extends AbstractWorkbenchEntity> exten
         return 1.0F;
     }
 
+    /**
+     * Handle teardown of a multi-block workbench when a player destroys one of its parts,
+     * ensuring the master/slave parts are removed consistently and loot is produced exactly once.
+     *
+     * <p>Server-side behavior:
+     * - Computes the master (bottom-left) position for the workbench and whether the broken part is the master.
+     * - Iterates the workbench footprint (2x2 if wide and tall, or the corresponding subset) and removes other parts:
+     *   - If the master is broken, other parts are removed silently (no drops).
+     *   - If a slave is broken, the master is destroyed (producing drops unless the player is in creative) and other slaves are removed silently.
+     * - Emits GameEvent.BLOCK_DESTROY for each part that is removed.
+     * - If a slave was broken by a non-creative player, prevents the slave part itself from dropping to avoid duplicate loot.
+     *
+     * @param level  the world where the destruction occurs
+     * @param pos    the position of the part being destroyed
+     * @param state  the block state of the part being destroyed (may be modified to suppress drops)
+     * @param player the player performing the destruction
+     * @return the BlockState returned by the superclass implementation after custom teardown handling
+     */
     @Override
     public BlockState playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
         if (!level.isClientSide()) {

--- a/src/main/java/com/tcm/MineTale/registry/ModBlocks.java
+++ b/src/main/java/com/tcm/MineTale/registry/ModBlocks.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.block.Blocks;
 
+import static net.minecraft.world.level.block.Blocks.litBlockEmission;
 import static net.minecraft.world.level.block.Blocks.logProperties;
 
 public class ModBlocks {
@@ -59,14 +60,18 @@ public class ModBlocks {
 	public static final Block FURNACE_WORKBENCH_BLOCK_T1 = register(
 		"furnace_workbench_block_t1",
 		(props) -> new FurnaceWorkbench(props, ModTiers.TIER_1),
-		BlockBehaviour.Properties.of().sound(SoundType.STONE).noOcclusion(),
-		true
+		BlockBehaviour.Properties.of().sound(SoundType.STONE).noOcclusion()
+				.requiresCorrectToolForDrops().strength(3.5F)
+				.lightLevel(litBlockEmission(13)),
+			true
 	);
 
 	public static final Block FURNACE_WORKBENCH_BLOCK_T2 = register(
 		"furnace_workbench_block_t2",
 		(props) -> new FurnaceWorkbench(props, ModTiers.TIER_2),
-		BlockBehaviour.Properties.of().sound(SoundType.STONE).noOcclusion(),
+		BlockBehaviour.Properties.of().sound(SoundType.STONE).noOcclusion()
+				.requiresCorrectToolForDrops().strength(3.5F)
+				.lightLevel(litBlockEmission(13)),
 		true
 	);
 

--- a/src/main/java/com/tcm/MineTale/registry/ModItems.java
+++ b/src/main/java/com/tcm/MineTale/registry/ModItems.java
@@ -3,18 +3,26 @@ package com.tcm.MineTale.registry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import com.tcm.MineTale.MineTale;
 import com.tcm.MineTale.item.ModCreativeTab;
 
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ItemContainerContents;
+import net.minecraft.world.level.block.Block;
+
+import static net.minecraft.world.item.Items.registerBlock;
 
 public class ModItems {
 

--- a/src/main/java/com/tcm/MineTale/util/ModLootTableModifiers.java
+++ b/src/main/java/com/tcm/MineTale/util/ModLootTableModifiers.java
@@ -1,0 +1,37 @@
+package com.tcm.MineTale.util;
+
+import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
+import net.minecraft.world.item.Items;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+
+public class ModLootTableModifiers {
+    private static final Identifier SHORT_GRASS_ID = Identifier.fromNamespaceAndPath("minecraft", "blocks/short_grass");
+    private static final Identifier TALL_GRASS_ID = Identifier.fromNamespaceAndPath("minecraft", "blocks/tall_grass");
+
+    public static void modifyLootTables() {
+        LootTableEvents.MODIFY.register((key, tableBuilder, sources, registry) -> {
+            if (SHORT_GRASS_ID.equals(key.identifier())) {
+                LootPool.Builder poolBuilder = LootPool.lootPool()
+                        .setRolls(ConstantValue.exactly(1))
+                        .add(LootItem.lootTableItem(Items.AIR)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1f, 1f))))
+                        .add(LootItem.lootTableItem(Items.STICK)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1f, 3f))));
+                tableBuilder.pool(poolBuilder.build());
+            }
+
+            if (TALL_GRASS_ID.equals(key.identifier())) {
+                LootPool.Builder poolBuilder = LootPool.lootPool()
+                        .setRolls(ConstantValue.exactly(1))
+                        .add(LootItem.lootTableItem(Items.STICK).setWeight(1)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1f, 4f))));
+                tableBuilder.pool(poolBuilder.build());
+            }
+        });
+    }
+}

--- a/src/main/java/com/tcm/MineTale/util/ModLootTableModifiers.java
+++ b/src/main/java/com/tcm/MineTale/util/ModLootTableModifiers.java
@@ -13,6 +13,16 @@ public class ModLootTableModifiers {
     private static final Identifier SHORT_GRASS_ID = Identifier.fromNamespaceAndPath("minecraft", "blocks/short_grass");
     private static final Identifier TALL_GRASS_ID = Identifier.fromNamespaceAndPath("minecraft", "blocks/tall_grass");
 
+    /**
+     * Registers a listener that modifies the loot tables for short and tall grass.
+     *
+     * <p>When the listener sees the short grass loot table, it replaces its pools with a single-roll
+     * pool that can produce AIR (count exactly 1) and STICK (count between 1 and 3). When the listener
+     * sees the tall grass loot table, it replaces its pools with a single-roll pool that can produce
+     * STICK (weight 1, count between 1 and 4).
+     *
+     * <p>This method registers the modification via LootTableEvents.MODIFY.
+     */
     public static void modifyLootTables() {
         LootTableEvents.MODIFY.register((key, tableBuilder, sources, registry) -> {
             if (SHORT_GRASS_ID.equals(key.identifier())) {


### PR DESCRIPTION
Workbenchs drops are a bit broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added data- and runtime support for block loot tables and richer block drop behaviors.
  * Multi-block workbenches now correctly tear down linked parts and emit destruction events.
  * Recipe ingredient checks improved to consider nearby inventories.

* **Bug Fixes**
  * Grass now reliably yields stick drops.
  * Workbench blocks have corrected mining requirements, strength, light emission, and drop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->